### PR TITLE
GPTEINFRA-16761 helm: Add per-user ApplicationSet for multi-user deployments

### DIFF
--- a/examples/helm/templates/applicationset-per-user.yaml
+++ b/examples/helm/templates/applicationset-per-user.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.multi_user }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: per-user
+  namespace: openshift-gitops
+spec:
+  generators:
+  - list:
+      elements:
+{{- range .Values.multi_user.users }}
+      - user: {{ .username | quote }}
+{{- end }}
+  template:
+    metadata:
+      name: "{{`{{ user }}`}}-hello-world"
+      namespace: openshift-gitops
+      finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    spec:
+      destination:
+        namespace: "{{`{{ user }}`}}-hello-world"
+        server: 'https://kubernetes.default.svc'
+      project: default
+      syncPolicy:
+        syncOptions:
+        - CreateNamespace=true
+        automated:
+          prune: false
+          selfHeal: false
+      source:
+        repoURL: {{ .Values.gitops.repoUrl }}
+        targetRevision: {{ .Values.gitops.revision }}
+        path: {{ .Values.gitops.basePath }}/components/hello-world
+        helm:
+          values: |
+            demo:
+              enabled: true
+              namespace: {{`{{ user }}`}}-hello-world
+{{- end }}

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -81,3 +81,14 @@ deployer:
 
 fieldContent:
   deploymentType: "helm"
+
+# Example for deployment of applications per user
+# checkout templates/applicationset-per-user.yaml
+# multi_user:
+#     num_users: 5
+#     users:
+#     -   username: user1
+#     -   username: user2
+#     -   username: user3
+#     -   username: user4
+#     -   username: user5


### PR DESCRIPTION
Add an ApplicationSet template that generates individual ArgoCD Applications for each user defined in multi_user.users. This enables per-user namespace isolation with hello-world as an example component.

Ref: https://github.com/rhpds/core_workloads/pull/161
Ref: GPTEINFRA-16761